### PR TITLE
implemented cached network image

### DIFF
--- a/lib/ui/common/image_loader.dart
+++ b/lib/ui/common/image_loader.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class ImageLoader extends StatelessWidget {
   final String? url;
@@ -17,23 +18,16 @@ class ImageLoader extends StatelessWidget {
             width: 0,
             height: 0,
           )
-        : Image.network(
-            url!,
+        : CachedNetworkImage(
+            imageUrl: url!,
             width: fullSize ? null : width,
             height: fullSize ? null : height,
-            loadingBuilder: (BuildContext context, Widget child,
-                ImageChunkEvent? loadingProgress) {
-              if (loadingProgress == null) return child;
-              return Center(
-                child: CircularProgressIndicator(
-                  color: Theme.of(context).colorScheme.secondary,
-                  value: loadingProgress.expectedTotalBytes != null
-                      ? loadingProgress.cumulativeBytesLoaded /
-                          loadingProgress.expectedTotalBytes!
-                      : null,
-                ),
-              );
-            },
+            placeholder: (context, url) => Center(
+              child: CircularProgressIndicator(
+                color: Theme.of(context).colorScheme.secondary,
+              ),
+            ),
+            errorWidget: (context, url, error) => Icon(Icons.error),
           );
   }
 }

--- a/lib/ui/common/image_loader.dart
+++ b/lib/ui/common/image_loader.dart
@@ -22,11 +22,14 @@ class ImageLoader extends StatelessWidget {
             imageUrl: url!,
             width: fullSize ? null : width,
             height: fullSize ? null : height,
-            placeholder: (context, url) => Center(
-              child: CircularProgressIndicator(
-                color: Theme.of(context).colorScheme.secondary,
-              ),
-            ),
+            progressIndicatorBuilder: (context, url, downloadProgress) {
+              return Center(
+                child: CircularProgressIndicator(
+                  color: Theme.of(context).colorScheme.secondary,
+                  value: downloadProgress.progress,
+                ),
+              );
+            },
             errorWidget: (context, url, error) => Icon(Icons.error),
           );
   }

--- a/lib/ui/events/event_tile.dart
+++ b/lib/ui/events/event_tile.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:campus_mobile_experimental/app_constants.dart';
 import 'package:campus_mobile_experimental/core/models/events.dart';
 import 'package:campus_mobile_experimental/core/providers/events.dart';
@@ -22,7 +23,7 @@ class EventTile extends StatelessWidget {
   Widget buildEventTile(BuildContext context) {
     return Container(
       width: tileWidth,
-      height: 300,
+      height: 285,
       margin: EdgeInsets.zero,
       child: InkWell(
         onTap: () {
@@ -78,28 +79,24 @@ class EventTile extends StatelessWidget {
         ? Container(
             child: Image(
             image: AssetImage('assets/images/UCSDMobile_sharp.png'),
-            height: 150,
+            height: 125,
             width: tileWidth,
             fit: BoxFit.fill,
           ))
-        : Image.network(
-            url,
-            loadingBuilder: (BuildContext context, Widget child,
-                ImageChunkEvent? loadingProgress) {
-              if (loadingProgress == null) return child;
+        : CachedNetworkImage(
+            imageUrl: url,
+            height: 125,
+            width: tileWidth,
+            fit: BoxFit.fill,
+            progressIndicatorBuilder: (context, url, downloadProgress) {
               return Center(
                 child: CircularProgressIndicator(
                   color: Theme.of(context).colorScheme.secondary,
-                  value: loadingProgress.expectedTotalBytes != null
-                      ? loadingProgress.cumulativeBytesLoaded /
-                          loadingProgress.expectedTotalBytes!
-                      : null,
+                  value: downloadProgress.progress,
                 ),
               );
             },
-            fit: BoxFit.fill,
-            height: 150,
-            width: tileWidth,
+            errorWidget: (context, url, error) => Icon(Icons.error),
           );
   }
 

--- a/lib/ui/events/events_list.dart
+++ b/lib/ui/events/events_list.dart
@@ -64,9 +64,5 @@ class EventsList extends StatelessWidget {
             : EventsAll(),
       );
     }
-    // ListView(
-    //   children:
-    //   ListTile.divideTiles(tiles: eventTiles, context: context)
-    //       .toList(),
   }
 }

--- a/lib/ui/events/events_view_all.dart
+++ b/lib/ui/events/events_view_all.dart
@@ -30,11 +30,9 @@ class EventsAll extends StatelessWidget {
     if (listOfEvents.length > 0) {
       return GridView.count(
         crossAxisCount: 2,
-        crossAxisSpacing: 1,
-        mainAxisSpacing: 8,
         children: eventTiles,
         childAspectRatio: MediaQuery.of(context).size.width /
-            (MediaQuery.of(context).size.height / 1.4),
+            (MediaQuery.of(context).size.height / 1.6),
       );
     } else {
       return ContainerView(

--- a/lib/ui/mystudentchart/mystudentchart.dart
+++ b/lib/ui/mystudentchart/mystudentchart.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:campus_mobile_experimental/app_constants.dart';
 import 'package:campus_mobile_experimental/core/providers/cards.dart';
 import 'package:campus_mobile_experimental/ui/common/card_container.dart';
@@ -32,10 +33,12 @@ class MyStudentChartCard extends StatelessWidget {
       child: Row(
         children: <Widget>[
           Container(
-            child: Image.asset(
-              'assets/images/MyChartLogo.png',
+            child: CachedNetworkImage(
+              imageUrl: 'assets/images/MyChartLogo.png',
               fit: BoxFit.contain,
               height: 56,
+              placeholder: (context, url) => CircularProgressIndicator(),
+              errorWidget: (context, url, error) => Icon(Icons.error),
             ),
             padding: EdgeInsets.only(
               left: 10,

--- a/lib/ui/scanner/native_scanner_card.dart
+++ b/lib/ui/scanner/native_scanner_card.dart
@@ -37,8 +37,8 @@ class NativeScannerCard extends StatelessWidget {
       child: Row(
         children: <Widget>[
           Container(
-            child: Image.asset(
-              'assets/images/QRScanIcon.png',
+            child: Image(
+              image: AssetImage('assets/images/QRScanIcon.png'),
               fit: BoxFit.contain,
               height: 56,
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -161,6 +161,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.6.1"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: fd3d0dc1d451f9a252b32d95d3f0c3c487bc41a75eba2e6097cb0b9c71491b15
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.3"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: bb2b8403b4ccdc60ef5f25c70dead1f3d32d24b9d6117cfc087f496b178594a7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: b8eb814ebfcb4dea049680f8c1ffb2df399e4d03bf7a352c775e26fa06e02fa0
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   characters:
     dependency: transitive
     description:
@@ -446,6 +470,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_blurhash:
+    dependency: transitive
+    description:
+      name: flutter_blurhash
+      sha256: "05001537bd3fac7644fa6558b09ec8c0a3f2eba78c0765f88912882b1331a5c6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   flutter_cache_manager:
     dependency: transitive
     description:
@@ -867,6 +899,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "107f3ed1330006a3bea63615e81cf637433f5135a52466c7caa0e7152bca9143"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   just_audio: ^0.9.31
   just_audio_background: ^0.0.1-beta.9
   device_info_plus: ^9.1.2
+  cached_network_image: ^3.2.3
 dev_dependencies:
   build_runner: 2.0.2
   flutter_test:


### PR DESCRIPTION
## Summary
Implemented the CachedNetworkImage function in the place of the Image.Network function.
I modified the `image_loader.dart` file inside the `ui/common` directory because it seems to be the responsible of loading all the images within the app. Thus, this should cache all the images on the app. To be tested (need to solve the red screen issue).
